### PR TITLE
Allow disabling version mismatch messages at the console.

### DIFF
--- a/src/alembic/still.clj
+++ b/src/alembic/still.clj
@@ -158,14 +158,19 @@ http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4388202
 
 
 (defn add-dependency
-  "Add a dependency to the classpath.  Returns a sequence of maps, each
-containing a :coords vector, a :jar path and possibly a :current-version
-string.  If the dependency is already on the classpath, returns nil."
-  [still dependency repositories]
+  "Add a dependency to the classpath. Returns a sequence of maps, each
+containing a :coords vector, a :jar path and possibly
+a :current-version string. If the dependency is already on the
+classpath, returns nil. If the optional parameter :verbose is
+true (the default), then WARN messages will be printed to the console
+if a version of a library is requested and the classpath already
+contains a different version of the same library"
+  [still dependency repositories
+   & {:keys [verbose] :as opts :or {verbose true}}]
   (when-not (meta-inf-properties-url still dependency)
     (let [dep-jars (->> (resolve-dependency still dependency repositories)
                         (current-dep-versions still))]
-      (warn-mismatch-versions dep-jars)
+      (when verbose (warn-mismatch-versions dep-jars))
       (add-dep-jars still dep-jars)
       (swap! still (fn [m]
                      (-> m
@@ -183,12 +188,18 @@ string.  If the dependency is already on the classpath, returns nil."
 
 `:still`
 : specifies an alembic still to use.  This would be considered advanced
-  usage (see the tests for an example)."
-  [dependency & {:keys [repositories still]
+  usage (see the tests for an example).
+
+`:verbose`
+: specifies whether WARN messages should be printed to the console if
+  a version of library is requests and there is already a different
+  version of the same library in the classpath. Defaults to true"
+  [dependency & {:keys [repositories still verbose]
                  :or {still the-still
-                      repositories (project-repositories still)}}]
+                      repositories (project-repositories still)
+                      verbose true}}]
   (let [repositories (into {} repositories)]
-    (add-dependency still dependency repositories)))
+    (add-dependency still dependency repositories :verbose verbose)))
 
 (defn dependencies-added
   ([still]


### PR DESCRIPTION
They can be turned off by passing `false` to the option `:verbose?` in
`distill` and `add-dependency`.
