### PR TITLE
Update to lein-as-resource 2.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :url "https://github.com/pallet/alembic"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[lein-as-resource "2.5.0"]
+  :dependencies [[lein-as-resource "2.7.0"]
                  [org.flatland/classlojure "0.7.0"]
                  [org.tcrawley/dynapath "0.2.3"]]
   :exclusions [[org.clojure/clojure]]


### PR DESCRIPTION
To fix the issue with cider 0.12.0+, which mentioned in lein-as-resource merge request, please merge the request of lein-as-resources first.
